### PR TITLE
No pan incorrectly sets state change on pan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pinch to zoom, rotate and translate.
 
 Double Click to reset.
 
-Library size is 962 bytes (after gzip), 2119 bytes (before gzip)
+Library size is 956 bytes (after gzip), 2106 bytes (before gzip)
 
 For a DEMO check this:
     http://anitasv.github.io/zoom/

--- a/zoom.js
+++ b/zoom.js
@@ -305,7 +305,9 @@ function Zoom(elem, config) {
                 tapped = setTimeout(function() {
                     tapped = false;
                 }, 300);
-                me.zooming = true;
+                if (me.config.pan) {
+                    me.zooming = true;
+                }
             } else {
                 me.zooming = false;                
                 tapped = false;
@@ -318,11 +320,6 @@ function Zoom(elem, config) {
         var t = evt.touches;
         if (!t) {
             return false;
-        }
-        if (t.length == 1) {
-            if (!me.config.pan) {
-                return false;
-            }
         }
         if (!me.zooming) {
             // To prevent possible potential reorder of events.


### PR DESCRIPTION
when panning in no pan mode, state is incorrectly set to zooming, making touchend trigger zoom completion operation