### PR TITLE
Fix offset

### DIFF
--- a/zoom.js
+++ b/zoom.js
@@ -276,6 +276,10 @@ function Zoom(elem, config, wnd) {
 
     this.wnd = wnd || window;
 
+    // trigger browser optimisations for the transition
+    // see https://dev.opera.com/articles/css-will-change-property/
+    elem.style['will-change'] = 'transform';
+
     elem.style['transform-origin'] = '0 0';
 
     var getCoordsDouble = function(t) {

--- a/zoom.js
+++ b/zoom.js
@@ -283,7 +283,7 @@ function Zoom(elem, config, wnd) {
     elem.style['transform-origin'] = '0 0';
 
     var getCoordsDouble = function(t) {
-        var rect = elem.getBoundingClientRect();
+        var rect = elem.parentNode.getBoundingClientRect();
         var oX = rect.left;
         var oY = rect.top;
         return [
@@ -293,7 +293,7 @@ function Zoom(elem, config, wnd) {
     };
 
     var getCoordsSingle = function(t) {
-        var rect = elem.getBoundingClientRect();
+        var rect = elem.parentNode.getBoundingClientRect();
         var oX = rect.left;
         var oY = rect.top;
         var x = t[0].pageX - oX;

--- a/zoom.js
+++ b/zoom.js
@@ -293,8 +293,9 @@ function Zoom(elem, config, wnd) {
     };
 
     var getCoordsSingle = function(t) {
-        var oX = elem.offsetLeft;
-        var oY = elem.offsetTop;
+        var rect = elem.getBoundingClientRect();
+        var oX = rect.left;
+        var oY = rect.top;
         var x = t[0].pageX - oX;
         var y = t[0].pageY - oY;
         return [

--- a/zoom.js
+++ b/zoom.js
@@ -283,8 +283,9 @@ function Zoom(elem, config, wnd) {
     elem.style['transform-origin'] = '0 0';
 
     var getCoordsDouble = function(t) {
-        var oX = elem.offsetLeft;
-        var oY = elem.offsetTop;
+        var rect = elem.getBoundingClientRect();
+        var oX = rect.left;
+        var oY = rect.top;
         return [
             [t[0].pageX - oX, t[0].pageY - oY],
             [t[1].pageX - oX, t[1].pageY - oY]


### PR DESCRIPTION
If `elem` was within a positioned element, `getCoords` would return the wrong coordinates.