### PR TITLE
Add `destroy()` method

### DIFF
--- a/zoom.js
+++ b/zoom.js
@@ -276,6 +276,10 @@ function Zoom(elem, config, wnd) {
 
     this.wnd = wnd || window;
 
+    // trigger browser optimisations for the transition
+    // see https://dev.opera.com/articles/css-will-change-property/
+    elem.style['will-change'] = 'transform';
+
     elem.style['transform-origin'] = '0 0';
 
     var getCoordsDouble = function(t) {


### PR DESCRIPTION
If event listeners are not released when `elem` is removed from the DOM, there will be memory leaks and errors. This PR gives consumers the option of cleaning up responsibly.